### PR TITLE
Handles JSON::ParserError for register, login and sync commands

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe Tsks::CLI do
           described_class.start ["register", "--email=@", "--password=s"]
         }.to output("Failed to connect to the API.\n").to_stdout
       end
+
+      it "Shows a feedback message when not processing the API's response" do
+        allow(Tsks::Request).to receive(:post).and_raise(JSON::ParserError)
+        expect {
+          described_class.start ["register", "--email=@", "--password=s"]
+        }.to output("Error on reading data from the API.\n").to_stdout
+      end
     end
 
     describe "login" do
@@ -290,6 +297,13 @@ RSpec.describe Tsks::CLI do
         expect {
           described_class.start ["login", "--email=@", "--password=s"]
         }.to output("Failed to connect to the API.\n").to_stdout
+      end
+
+      it "Shows a feedback message when not processing the API's response" do
+        allow(Tsks::Request).to receive(:post).and_raise(JSON::ParserError)
+        expect {
+          described_class.start ["login", "--email=@", "--password=s"]
+        }.to output("Error on reading data from the API.\n").to_stdout
       end
     end
 
@@ -400,6 +414,14 @@ RSpec.describe Tsks::CLI do
         expect {
           described_class.start ["sync"]
         }.to output("Failed to connect to the API.\n").to_stdout
+      end
+
+      it "Shows a feedback message when not processing the API's response" do
+        subject
+        allow(Tsks::Request).to receive(:post).and_raise(JSON::ParserError)
+        expect {
+          described_class.start ["sync"]
+        }.to output("Error on reading data from the API.\n").to_stdout
       end
     end
   end


### PR DESCRIPTION
Add a error rescue for `JSON::ParserError` exception for register, login and sync commands. 
This PR, together with #3, adds error handling to the two most common exceptions caughted during development workflows.

closes #2