### PR TITLE
Handles SocketError for register, login and sync

### DIFF
--- a/lib/tsks/cli.rb
+++ b/lib/tsks/cli.rb
@@ -94,7 +94,7 @@ module Tsks
         elsif res && res[:status_code] == 409
           puts "This e-mail is already registered."
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, SocketError
         puts "Failed to connect to the API."
       rescue JSON::ParserError
         puts "Error on reading data from the API."
@@ -121,7 +121,7 @@ module Tsks
         elsif res && res[:status_code] == 403
           puts "Invalid e-mail or password."
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, SocketError
         puts "Failed to connect to the API."
       rescue JSON::ParserError
         puts "Error on reading data from the API."
@@ -167,7 +167,7 @@ module Tsks
             puts "Your tsks were succesfully synchronized."
           end
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, SocketError
         puts "Failed to connect to the API."
       rescue JSON::ParserError
         puts "Error on reading data from the API."

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -229,6 +229,13 @@ RSpec.describe Tsks::CLI do
           described_class.start ["register", "--email=@", "--password=s"]
         }.to output("Error on reading data from the API.\n").to_stdout
       end
+
+      it "Shows a feedback message when the API is off or sleeping" do
+        allow(Tsks::Request).to receive(:post).and_raise(SocketError)
+        expect {
+          described_class.start ["register", "--email=@", "--password=s"]
+        }.to output("Failed to connect to the API.\n").to_stdout
+      end
     end
 
     describe "login" do
@@ -304,6 +311,13 @@ RSpec.describe Tsks::CLI do
         expect {
           described_class.start ["login", "--email=@", "--password=s"]
         }.to output("Error on reading data from the API.\n").to_stdout
+      end
+
+      it "Shows a feedback message when the API is off or sleeping" do
+        allow(Tsks::Request).to receive(:post).and_raise(SocketError)
+        expect {
+          described_class.start ["login", "--email=@", "--password=s"]
+        }.to output("Failed to connect to the API.\n").to_stdout
       end
     end
 
@@ -418,10 +432,18 @@ RSpec.describe Tsks::CLI do
 
       it "Shows a feedback message when not processing the API's response" do
         subject
-        allow(Tsks::Request).to receive(:post).and_raise(JSON::ParserError)
+        allow(Tsks::Request).to receive(:get).and_raise(JSON::ParserError)
         expect {
           described_class.start ["sync"]
         }.to output("Error on reading data from the API.\n").to_stdout
+      end
+
+      it "Shows a feedback message when the API is off or sleeping" do
+        subject
+        allow(Tsks::Request).to receive(:get).and_raise(SocketError)
+        expect {
+          described_class.start ["sync"]
+        }.to output("Failed to connect to the API.\n").to_stdout
       end
     end
   end


### PR DESCRIPTION
Add an error rescue for `SocketError` exception for register, login and sync commands and refactor a previously implemented test suite for the `sync` command.