### PR TITLE
Removes dotenv as a project dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
-gem "dotenv", "~> 2.7.6"
 gem "thor", "~> 1.0.1"
 gem "sqlite3", "~> 1.4.2"
 gem "httparty", "~> 0.18.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
-    dotenv (2.7.6)
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -45,7 +44,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dotenv (~> 2.7.6)
   httparty (~> 0.18.1)
   rake (~> 12.0)
   rspec (~> 3.0)

--- a/lib/tsks.rb
+++ b/lib/tsks.rb
@@ -1,4 +1,3 @@
-require "dotenv/load"
 require "tsks/version"
 require "tsks/cli"
 

--- a/lib/tsks/cli.rb
+++ b/lib/tsks/cli.rb
@@ -6,10 +6,14 @@ require "tsks/actions"
 
 module Tsks
   class CLI < Thor
-    @setup_folder = File.expand_path ENV["SETUP_FOLDER"] || "~/.tsks"
+    @setup_folder = File.expand_path "~/.tsks"
 
     def self.setup_folder
       @setup_folder
+    end
+
+    def self.setup_folder= folder_path
+      @setup_folder = folder_path
     end
 
     desc "version", ""

--- a/lib/tsks/request.rb
+++ b/lib/tsks/request.rb
@@ -2,7 +2,7 @@ require "httparty"
 
 module Tsks
   class Request
-    @base_uri = ENV["BASE_API_URI"] || "https://tsks-api.herokuapp.com/v1"
+    @base_uri = "https://tsks-api.herokuapp.com/v1"
 
     def self.base_uri
       @base_uri

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe Tsks::CLI do
   context "Commands" do
     before :all do
-      @setup_folder = described_class.setup_folder
+      @setup_folder = File.expand_path "~/.tsks_test"
+      described_class.setup_folder = @setup_folder
     end
 
     describe "version" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "bundler/setup"
-require "dotenv/load"
 require "tsks/storage"
 require "tsks/request"
 require "tsks/actions"

--- a/tsks.gemspec
+++ b/tsks.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "dotenv"
   spec.add_dependency "thor"
   spec.add_dependency "sqlite3"
   spec.add_dependency "httparty"


### PR DESCRIPTION
It should've be loaded only for development environments but it was being called on the production code. So when running `gem install tsks` it was triggering an `LoadError` because of the missing dependency.

At the end of the day `dotenv` was not being useful for this purpose. :fire: it!